### PR TITLE
Better time ago display

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The flat phone image that I used to create the banner on this ReadMe and Blog is
 I used these photos as avatars:
 
 - Bengal: Tyler T CC BY-SA 3.0
-- Siamese: Karin Langner-Bahmann CC BY-SA 3.0 
-- Sphinx: Christopher Voelker CC-BY-3.0 
+- Siamese: Karin Langner-Bahmann CC BY-SA 3.0
+- Sphinx: Christopher Voelker CC-BY-3.0
 - Ragdoll: Simone Johnsson CC BY-SA 2.0
 - Persian: UnionMaminia CC BY-SA 3.0
 - Korat: Heikkisiltala CC BY-SA 3.0

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "paper-input": "Polymer/paper-input#~0.5.2",
     "paper-fab": "Polymer/paper-fab#~0.5.2",
     "core-item": "Polymer/core-item#~0.5.2",
-    "pubnub-polymer": "*"
+    "pubnub-polymer": "*",
+    "time-elements": "~0.4.0"
   }
 }

--- a/bower_components/time-elements/.bower.json
+++ b/bower_components/time-elements/.bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "time-elements",
+  "version": "0.4.0",
+  "main": "time-elements.js",
+  "devDependencies": {
+    "CustomElements": "0.2.3",
+    "es5-basic-shim": "1.0.6",
+    "MutationObserver": "0.2.0",
+    "qunit": "1.14.0",
+    "WeakMap": "0.2.1"
+  },
+  "ignore": [
+    ".*",
+    "*.md",
+    "examples/",
+    "Makefile",
+    "package.json",
+    "test/"
+  ],
+  "homepage": "https://github.com/github/time-elements",
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "ab1a5a5d34301bc5b441b56a629ddc48788b19dc"
+  },
+  "_source": "git://github.com/github/time-elements.git",
+  "_target": "~0.4.0",
+  "_originalSource": "time-elements",
+  "_direct": true
+}

--- a/bower_components/time-elements/LICENSE
+++ b/bower_components/time-elements/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower_components/time-elements/bower.json
+++ b/bower_components/time-elements/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "time-elements",
+  "version": "0.4.0",
+  "main": "time-elements.js",
+  "devDependencies": {
+    "CustomElements": "0.2.3",
+    "es5-basic-shim": "1.0.6",
+    "MutationObserver": "0.2.0",
+    "qunit": "1.14.0",
+    "WeakMap": "0.2.1"
+  },
+  "ignore": [
+    ".*",
+    "*.md",
+    "examples/",
+    "Makefile",
+    "package.json",
+    "test/"
+  ]
+}

--- a/bower_components/time-elements/time-elements.js
+++ b/bower_components/time-elements/time-elements.js
@@ -1,0 +1,525 @@
+(function() {
+  'use strict';
+
+  // Shout out to https://github.com/basecamp/local_time/blob/master/app/assets/javascripts/local_time.js.coffee
+  var weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+  function pad(num) {
+    return ('0' + num).slice(-2);
+  }
+
+  function strftime(time, formatString) {
+    var day = time.getDay();
+    var date = time.getDate();
+    var month = time.getMonth();
+    var year = time.getFullYear();
+    var hour = time.getHours();
+    var minute = time.getMinutes();
+    var second = time.getSeconds();
+    return formatString.replace(/%([%aAbBcdeHIlmMpPSwyYZz])/g, function(_arg) {
+      var match;
+      var modifier = _arg[1];
+      switch (modifier) {
+        case '%':
+          return '%';
+        case 'a':
+          return weekdays[day].slice(0, 3);
+        case 'A':
+          return weekdays[day];
+        case 'b':
+          return months[month].slice(0, 3);
+        case 'B':
+          return months[month];
+        case 'c':
+          return time.toString();
+        case 'd':
+          return pad(date);
+        case 'e':
+          return date;
+        case 'H':
+          return pad(hour);
+        case 'I':
+          return pad(strftime(time, '%l'));
+        case 'l':
+          if (hour === 0 || hour === 12) {
+            return 12;
+          } else {
+            return (hour + 12) % 12;
+          }
+          break;
+        case 'm':
+          return pad(month + 1);
+        case 'M':
+          return pad(minute);
+        case 'p':
+          if (hour > 11) {
+            return 'PM';
+          } else {
+            return 'AM';
+          }
+          break;
+        case 'P':
+          if (hour > 11) {
+            return 'pm';
+          } else {
+            return 'am';
+          }
+          break;
+        case 'S':
+          return pad(second);
+        case 'w':
+          return day;
+        case 'y':
+          return pad(year % 100);
+        case 'Y':
+          return year;
+        case 'Z':
+          match = time.toString().match(/\((\w+)\)$/);
+          return match ? match[1] : '';
+        case 'z':
+          match = time.toString().match(/\w([+-]\d\d\d\d) /);
+          return match ? match[1] : '';
+      }
+    });
+  }
+
+  function RelativeTime(date) {
+    this.date = date;
+  }
+
+  RelativeTime.prototype.toString = function() {
+    var ago = this.timeElapsed();
+    if (ago) {
+      return ago;
+    } else {
+      return 'on ' + this.formatDate();
+    }
+  };
+
+  RelativeTime.prototype.timeElapsed = function() {
+    var ms = new Date().getTime() - this.date.getTime();
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    if (ms < 0) {
+      return 'just now';
+    } else if (sec < 10) {
+      return 'just now';
+    } else if (sec < 45) {
+      return sec + ' seconds ago';
+    } else if (sec < 90) {
+      return 'a minute ago';
+    } else if (min < 45) {
+      return min + ' minutes ago';
+    } else if (min < 90) {
+      return 'an hour ago';
+    } else if (hr < 24) {
+      return hr + ' hours ago';
+    } else if (hr < 36) {
+      return 'a day ago';
+    } else if (day < 30) {
+      return day + ' days ago';
+    } else {
+      return null;
+    }
+  };
+
+  RelativeTime.prototype.timeAgo = function() {
+    var ms = new Date().getTime() - this.date.getTime();
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    var month = Math.round(day / 30);
+    var year = Math.round(month / 12);
+    if (ms < 0) {
+      return 'just now';
+    } else if (sec < 10) {
+      return 'just now';
+    } else if (sec < 45) {
+      return sec + ' seconds ago';
+    } else if (sec < 90) {
+      return 'a minute ago';
+    } else if (min < 45) {
+      return min + ' minutes ago';
+    } else if (min < 90) {
+      return 'an hour ago';
+    } else if (hr < 24) {
+      return hr + ' hours ago';
+    } else if (hr < 36) {
+      return 'a day ago';
+    } else if (day < 30) {
+      return day + ' days ago';
+    } else if (day < 45) {
+      return 'a month ago';
+    } else if (month < 12) {
+      return month + ' months ago';
+    } else if (month < 18) {
+        return 'a year ago';
+    } else {
+      return year + ' years ago';
+    }
+  };
+
+  RelativeTime.prototype.microTimeAgo = function() {
+    var ms = new Date().getTime() - this.date.getTime();
+    var sec = ms / 1000;
+    var min = sec / 60;
+    var hr = min / 60;
+    var day = hr / 24;
+    var month = day / 30;
+    var year = month / 12;
+    if (min < 1) {
+      return '1m';
+    } else if (min < 60) {
+      return Math.round(min) + 'm';
+    } else if (hr < 24) {
+      return Math.round(hr) + 'h';
+    } else if (day < 365) {
+      return Math.round(day) + 'd';
+    } else {
+      return Math.round(year) + 'y';
+    }
+  };
+
+  // Private: Determine if the day should be formatted before the month name in
+  // the user's current locale. For example, `9 Jun` for en-GB and `Jun 9`
+  // for en-US.
+  //
+  // Returns true if the day appears before the month.
+  function isDayFirst() {
+    if (dayFirst !== null) {
+      return dayFirst;
+    }
+
+    if (!('Intl' in window)) {
+      return false;
+    }
+
+    var options = {day: 'numeric', month: 'short'};
+    var formatter = new window.Intl.DateTimeFormat(undefined, options);
+    var output = formatter.format(new Date(0));
+
+    dayFirst = !!output.match(/^\d/);
+    return dayFirst;
+  }
+  var dayFirst = null;
+
+  // Private: Determine if the year should be separated from the month and day
+  // with a comma. For example, `9 Jun 2014` in en-GB and `Jun 9, 2014` in en-US.
+  //
+  // Returns true if the date needs a separator.
+  function isYearSeparator() {
+    if (yearSeparator !== null) {
+      return yearSeparator;
+    }
+
+    if (!('Intl' in window)) {
+      return true;
+    }
+
+    var options = {day: 'numeric', month: 'short', year: 'numeric'};
+    var formatter = new window.Intl.DateTimeFormat(undefined, options);
+    var output = formatter.format(new Date(0));
+
+    yearSeparator = !!output.match(/\d,/);
+    return yearSeparator;
+  }
+  var yearSeparator = null;
+
+  // Private: Determine if the date occurs in the same year as today's date.
+  //
+  // date - The Date to test.
+  //
+  // Returns true if it's this year.
+  function isThisYear(date) {
+    var now = new Date();
+    return now.getUTCFullYear() === date.getUTCFullYear();
+  }
+
+  RelativeTime.prototype.formatDate = function() {
+    var format = isDayFirst() ? '%e %b' : '%b %e';
+    if (!isThisYear(this.date)) {
+      format += isYearSeparator() ? ', %Y': ' %Y';
+    }
+    return strftime(this.date, format);
+  };
+
+  RelativeTime.prototype.formatTime = function() {
+    if ('Intl' in window) {
+      var formatter = new window.Intl.DateTimeFormat(undefined, {hour: 'numeric', minute: '2-digit'});
+      return formatter.format(this.date);
+    } else {
+      return strftime(this.date, '%l:%M%P');
+    }
+  };
+
+
+  // Internal: Array tracking all elements attached to the document that need
+  // to be updated every minute.
+  var nowElements = [];
+
+  // Internal: Timer ID for `updateNowElements` interval.
+  var updateNowElementsId;
+
+  // Internal: Install a timer to refresh all attached relative-time elements every
+  // minute.
+  function updateNowElements() {
+    var time, i, len;
+    for (i = 0, len = nowElements.length; i < len; i++) {
+      time = nowElements[i];
+      time.textContent = time.getFormattedDate();
+    }
+  }
+
+
+  var ExtendedTimePrototype;
+  if ('HTMLTimeElement' in window) {
+    ExtendedTimePrototype = Object.create(window.HTMLTimeElement.prototype);
+  } else {
+    ExtendedTimePrototype = Object.create(window.HTMLElement.prototype);
+  }
+
+  // Internal: Refresh the time element's formatted date when an attribute changes.
+  //
+  // Returns nothing.
+  ExtendedTimePrototype.attributeChangedCallback = function(attrName, oldValue, newValue) {
+    if (attrName === 'datetime') {
+      var millis = Date.parse(newValue);
+      this._date = isNaN(millis) ? null : new Date(millis);
+    }
+
+    var title = this.getFormattedTitle();
+    if (title) {
+      this.setAttribute('title', title);
+    }
+
+    var text = this.getFormattedDate();
+    if (text) {
+      this.textContent = text;
+    }
+  };
+
+  // Internal: Format the ISO 8601 timestamp according to the user agent's
+  // locale-aware formatting rules. The element's existing `title` attribute
+  // value takes precedence over this custom format.
+  //
+  // Returns a formatted time String.
+  ExtendedTimePrototype.getFormattedTitle = function() {
+    if (!this._date) {
+      return;
+    }
+
+    if (this.hasAttribute('title')) {
+      return this.getAttribute('title');
+    }
+
+    if ('Intl' in window) {
+      var options = {day: 'numeric', month: 'short', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short'};
+      var formatter = new window.Intl.DateTimeFormat(undefined, options);
+      return formatter.format(this._date);
+    }
+
+    return this._date.toLocaleString();
+  };
+
+
+  var RelativeTimePrototype = Object.create(ExtendedTimePrototype);
+
+  RelativeTimePrototype.createdCallback = function() {
+    var value = this.getAttribute('datetime');
+    if (value) {
+      this.attributeChangedCallback('datetime', null, value);
+    }
+  };
+
+  RelativeTimePrototype.getFormattedDate = function() {
+    if (this._date) {
+      return new RelativeTime(this._date).toString();
+    }
+  };
+
+  RelativeTimePrototype.attachedCallback = function() {
+    nowElements.push(this);
+
+    if (!updateNowElementsId) {
+      updateNowElements();
+      updateNowElementsId = setInterval(updateNowElements, 60 * 1000);
+    }
+  };
+
+  RelativeTimePrototype.detachedCallback = function() {
+    var ix = nowElements.indexOf(this);
+    if (ix !== -1) {
+      nowElements.splice(ix, 1);
+    }
+
+    if (!nowElements.length) {
+      if (updateNowElementsId) {
+        clearInterval(updateNowElementsId);
+        updateNowElementsId = null;
+      }
+    }
+  };
+
+  var TimeAgoPrototype = Object.create(RelativeTimePrototype);
+  TimeAgoPrototype.getFormattedDate = function() {
+    if (this._date) {
+      var format = this.getAttribute('format');
+      if (format === 'micro') {
+        return new RelativeTime(this._date).microTimeAgo();
+      } else {
+        return new RelativeTime(this._date).timeAgo();
+      }
+    }
+  };
+
+
+  var LocalTimePrototype = Object.create(ExtendedTimePrototype);
+
+  LocalTimePrototype.createdCallback = function() {
+    var value;
+    if (value = this.getAttribute('datetime')) {
+      this.attributeChangedCallback('datetime', null, value);
+    }
+    if (value = this.getAttribute('format')) {
+      this.attributeChangedCallback('format', null, value);
+    }
+  };
+
+  // Formats the element's date, in the user's current locale, according to
+  // the formatting attribute values. Values are not passed straight through to
+  // an Intl.DateTimeFormat instance so that weekday and month names are always
+  // displayed in English, for now.
+  //
+  // Supported attributes are:
+  //
+  //   weekday - "short", "long"
+  //   year    - "numeric", "2-digit"
+  //   month   - "short", "long"
+  //   day     - "numeric", "2-digit"
+  //   hour    - "numeric", "2-digit"
+  //   minute  - "numeric", "2-digit"
+  //   second  - "numeric", "2-digit"
+  //
+  // Returns a formatted time String.
+  LocalTimePrototype.getFormattedDate = function() {
+    if (!this._date) {
+      return;
+    }
+
+    var date = formatDate(this) || '';
+    var time = formatTime(this) || '';
+    return (date + ' ' + time).trim();
+  };
+
+  // Private: Format a date according to the `weekday`, `day`, `month`,
+  // and `year` attribute values.
+  //
+  // This doesn't use Intl.DateTimeFormat to avoid creating text in the user's
+  // language when the majority of the surrounding text is in English. There's
+  // currently no way to separate the language from the format in Intl.
+  //
+  // el - The local-time element to format.
+  //
+  // Returns a date String or null if no date formats are provided.
+  function formatDate(el) {
+    // map attribute values to strftime
+    var props = {
+      weekday: {
+        'short': '%a',
+        'long': '%A'
+      },
+      day: {
+        'numeric': '%e',
+        '2-digit': '%d'
+      },
+      month: {
+        'short': '%b',
+        'long': '%B'
+      },
+      year: {
+        'numeric': '%Y',
+        '2-digit': '%y'
+      }
+    };
+
+    // build a strftime format string
+    var format = isDayFirst() ? 'weekday day month year' : 'weekday month day, year';
+    for (var prop in props) {
+      var value = props[prop][el.getAttribute(prop)];
+      format = format.replace(prop, value || '');
+    }
+
+    // clean up year separator comma
+    format = format.replace(/(\s,)|(,\s$)/, '');
+
+    // squeeze spaces from final string
+    return strftime(el._date, format).replace(/\s+/, ' ').trim();
+  }
+
+  // Private: Format a time according to the `hour`, `minute`, and `second`
+  // attribute values.
+  //
+  // el - The local-time element to format.
+  //
+  // Returns a time String or null if no time formats are provided.
+  function formatTime(el) {
+    // retrieve format settings from attributes
+    var options = {
+      hour: el.getAttribute('hour'),
+      minute: el.getAttribute('minute'),
+      second: el.getAttribute('second')
+    };
+
+    // remove unset format attributes
+    for (var opt in options) {
+      if (!options[opt]) {
+        delete options[opt];
+      }
+    }
+
+    // no time format attributes provided
+    if (Object.keys(options).length === 0) {
+      return;
+    }
+
+    // locale-aware formatting of 24 or 12 hour times
+    if ('Intl' in window) {
+      var formatter = new window.Intl.DateTimeFormat(undefined, options);
+      return formatter.format(el._date);
+    }
+
+    // fall back to strftime for non-Intl browsers
+    var timef = options.second ? '%H:%M:%S' : '%H:%M';
+    return strftime(el._date, timef);
+  }
+
+  // Public: RelativeTimeElement constructor.
+  //
+  //   var time = new RelativeTimeElement()
+  //   # => <time is='relative-time'></time>
+  //
+  window.RelativeTimeElement = document.registerElement('relative-time', {
+    prototype: RelativeTimePrototype,
+    'extends': 'time'
+  });
+
+  window.TimeAgoElement = document.registerElement('time-ago', {
+    prototype: TimeAgoPrototype,
+    'extends': 'time'
+  });
+
+  // Public: LocalTimeElement constructor.
+  //
+  //   var time = new LocalTimeElement()
+  //   # => <time is='local-time'></time>
+  //
+  window.LocalTimeElement = document.registerElement('local-time', {
+    prototype: LocalTimePrototype,
+    'extends': 'time'
+  });
+
+})();

--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,7 @@
 body {
     padding: 0;
     margin: 0;
-    font-family: "RobotoDraft", "Helvetica Neue", "Segoe UI Web Regular", "Segoe UI", Helvetica, Arial, sans-serif; 
+    font-family: "RobotoDraft", "Helvetica Neue", "Segoe UI Web Regular", "Segoe UI", Helvetica, Arial, sans-serif;
     color: #333;
     font-weight: 300;
 }

--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
 	<link rel="icon" sizes="128x128" href="images/app-icon-128.png">
 	<link rel="apple-touch-icon" sizes="128x128" href="images/app-icon-128.png">
 	<link rel="apple-touch-icon-precomposed" sizes="128x128" href="images/app-icon-128.png">
-	
+
 	<!-- Polymer -->
 	<script src="bower_components/webcomponentsjs/webcomponents.min.js"></script>
 
 	<link rel="import" href="bower_components/pubnub-polymer/pubnub-element.html">
 	<link rel="import" href="bower_components/core-scaffold/core-scaffold.html">
-	<link rel="import" href="bower_components/core-item/core-item.html"> 
+	<link rel="import" href="bower_components/core-item/core-item.html">
 	<link rel="import" href="bower_components/paper-input/paper-input.html">
 	<link rel="import" href="bower_components/paper-fab/paper-fab.html">
 	<link rel="import" href="x-chat-list.html">
@@ -32,7 +32,7 @@
 <template is="auto-binding">
 
 <core-pubnub publish_key="pub-c-156a6d5f-22bd-4a13-848d-b5b4d4b36695" subscribe_key="sub-c-f762fb78-2724-11e4-a4df-02ee2ddab7fe" uuid="{{uuid}}">
-	<core-pubnub-subscribe channel="polymer-chat" id="sub" on-callback="{{subscribeCallback}}" on-presence="{{presenceChanged}}" on-error="{{error}}"> 
+	<core-pubnub-subscribe channel="polymer-chat" id="sub" on-callback="{{subscribeCallback}}" on-presence="{{presenceChanged}}" on-error="{{error}}">
 	    <core-pubnub-publish channel="polymer-chat" message="" id="pub" on-error="{{error}}"></core-pubnub-publish>
 		<core-pubnub-history channel="polymer-chat" count="30" on-success="{{historyRetrieved}}" on-error="{{error}}"></core-pubnub-history>
     </core-pubnub-subscribe>

--- a/js/app.js
+++ b/js/app.js
@@ -4,15 +4,15 @@
     var uuid, avatar, color, cat;
 
     // Assign a uuid made of a random cat and a random color
-    var randomColor = function() {   
-        var colors = ['navy', 'slate', 'olive', 'moss', 'chocolate', 'buttercup', 'maroon', 'cerise', 'plum', 'orchid'];   
+    var randomColor = function() {
+        var colors = ['navy', 'slate', 'olive', 'moss', 'chocolate', 'buttercup', 'maroon', 'cerise', 'plum', 'orchid'];
         return colors[(Math.random() * colors.length) >>> 0];
     };
 
-    var randomCat = function() {   
-        var cats = ['tabby', 'bengal', 'persian', 'mainecoon', 'ragdoll', 'sphynx', 'siamese', 'korat', 'japanesebobtail', 'abyssinian', 'scottishfold'];           
-        return cats[(Math.random() * cats.length) >>> 0];        
-    }; 
+    var randomCat = function() {
+        var cats = ['tabby', 'bengal', 'persian', 'mainecoon', 'ragdoll', 'sphynx', 'siamese', 'korat', 'japanesebobtail', 'abyssinian', 'scottishfold'];
+        return cats[(Math.random() * cats.length) >>> 0];
+    };
 
     color = randomColor();
     cat = randomCat();
@@ -45,7 +45,7 @@
     };
 
     template.messageList = [];
-    
+
 
     /* PubNub Realtime Chat */
 
@@ -70,9 +70,9 @@
     };
 
     template.subscribeCallback = function(e) {
-        if(template.$.sub.messages.length > 0) { 
+        if(template.$.sub.messages.length > 0) {
             this.displayChatList(pastMsgs.concat(this.getListWithOnlineStatus(template.$.sub.messages)));
-        } 
+        }
     };
 
     template.presenceChanged = function(e) {
@@ -86,7 +86,7 @@
         // who are online
         if(d.action === 'join') {
             if(d.uuid.length > 35) { // console
-                d.uuid = 'the-mighty-big-cat'; 
+                d.uuid = 'the-mighty-big-cat';
             }
             onlineUuids.push(d.uuid);
         } else {
@@ -108,18 +108,18 @@
 
     template.historyRetrieved = function(e) {
         if(e.detail[0].length > 0) {
-            pastMsgs = this.getListWithOnlineStatus(e.detail[0]); 
+            pastMsgs = this.getListWithOnlineStatus(e.detail[0]);
             this.displayChatList(pastMsgs);
-        } 
+        }
     };
 
     template.publish = function() {
         if(!template.input) return;
 
         template.$.pub.message = {
-            uuid: uuid, 
-            avatar: avatar, 
-            color: color, 
+            uuid: uuid,
+            avatar: avatar,
+            color: color,
             text: template.input,
             timestamp: Date.now()
         };

--- a/js/app.js
+++ b/js/app.js
@@ -121,7 +121,7 @@
             avatar: avatar,
             color: color,
             text: template.input,
-            timestamp: Date.now()
+            timestamp: new Date().toISOString()
         };
         template.$.pub.publish();
         template.input = '';

--- a/lite.html
+++ b/lite.html
@@ -14,13 +14,13 @@
 	<link rel="icon" sizes="128x128" href="images/app-icon-128.png">
 	<link rel="apple-touch-icon" sizes="128x128" href="images/app-icon-128.png">
 	<link rel="apple-touch-icon-precomposed" sizes="128x128" href="images/app-icon-128.png">
-	
+
 	<!-- Polymer -->
 	<script src="bower_components/webcomponentsjs/webcomponents.min.js"></script>
 
 	<link rel="import" href="bower_components/pubnub-polymer/pubnub-element.html">
 	<link rel="import" href="bower_components/core-scaffold/core-scaffold.html">
-	<link rel="import" href="bower_components/core-item/core-item.html"> 
+	<link rel="import" href="bower_components/core-item/core-item.html">
 	<link rel="import" href="bower_components/paper-input/paper-input.html">
 	<link rel="import" href="bower_components/paper-fab/paper-fab.html">
 	<link rel="import" href="x-chat-list.html">
@@ -32,7 +32,7 @@
 <template is="auto-binding">
 
 <core-pubnub publish_key="pub-c-156a6d5f-22bd-4a13-848d-b5b4d4b36695" subscribe_key="sub-c-f762fb78-2724-11e4-a4df-02ee2ddab7fe" uuid="{{uuid}}">
-	<core-pubnub-subscribe channel="polymer-chat" id="sub" messages="{{messages}}" on-callback="{{subscribeCallback}}"> 
+	<core-pubnub-subscribe channel="polymer-chat" id="sub" messages="{{messages}}" on-callback="{{subscribeCallback}}">
 	    <core-pubnub-publish channel="polymer-chat" id="pub" message=""></core-pubnub-publish>
     </core-pubnub-subscribe>
 </core-pubnub>
@@ -82,15 +82,15 @@
     var uuid, avatar, color, cat;
 
     // Assign a uuid made of a random cat and a random color
-    var randomColor = function() {   
-        var colors = ['navy', 'slate', 'olive', 'moss', 'chocolate', 'buttercup', 'maroon', 'cerise', 'plum', 'orchid'];   
+    var randomColor = function() {
+        var colors = ['navy', 'slate', 'olive', 'moss', 'chocolate', 'buttercup', 'maroon', 'cerise', 'plum', 'orchid'];
         return colors[(Math.random() * colors.length) >>> 0];
     };
 
-    var randomCat = function() {   
-        var cats = ['tabby', 'bengal', 'persian', 'mainecoon', 'ragdoll', 'sphynx', 'siamese', 'korat', 'japanesebobtail', 'abyssinian', 'scottishfold'];           
-        return cats[(Math.random() * cats.length) >>> 0];        
-    }; 
+    var randomCat = function() {
+        var cats = ['tabby', 'bengal', 'persian', 'mainecoon', 'ragdoll', 'sphynx', 'siamese', 'korat', 'japanesebobtail', 'abyssinian', 'scottishfold'];
+        return cats[(Math.random() * cats.length) >>> 0];
+    };
 
     color = randomColor();
     cat = randomCat();
@@ -134,9 +134,9 @@
         if(!template.input) return;
 
         template.$.pub.message = {
-            uuid: uuid, 
-            avatar: avatar, 
-            color: color, 
+            uuid: uuid,
+            avatar: avatar,
+            color: color,
             text: template.input,
             timestamp: Date.now()
         };

--- a/lite.html
+++ b/lite.html
@@ -138,7 +138,7 @@
             avatar: avatar,
             color: color,
             text: template.input,
-            timestamp: Date.now()
+            timestamp: new Date().toISOString()
         };
         template.$.pub.publish();
         template.input = '';

--- a/x-chat-list.html
+++ b/x-chat-list.html
@@ -91,7 +91,7 @@ A single user list with a username, avatar, and desc.
 	    border-color: #ce6dbd;
 	}
 	</style>
-	
+
 	<section class="user-list" layout horizontal>
 		<div class="avatar {{color}}" style="background-image: url({{avatar}})">
 			<div class="status {{status}}"></div>
@@ -121,10 +121,10 @@ Polymer('x-chat-list', {
 		} else { // show date
 			var options = {month: 'short', day: 'numeric'};
 		}
-		
+
 		this.time = new Intl.DateTimeFormat(navigator.language, options).format(d);
 
-		
+
 		// Realtime update
 		// if(diff < 60) { // less than 1 min
 		// 	this.time = (diff >>> 0) + 's';

--- a/x-chat-list.html
+++ b/x-chat-list.html
@@ -6,6 +6,7 @@ A single user list with a username, avatar, and desc.
 	<x-chat-list avatar="url" username="name" message="hello" status="online" timestamp="1420145273945"></x-chat-list>
 
 -->
+<script src="bower_components/time-elements/time-elements.js"></script>
 <polymer-element name="x-chat-list" attributes="avatar color username text status timestamp">
   <template>
 	<style>
@@ -100,7 +101,7 @@ A single user list with a username, avatar, and desc.
 			<div class="username">{{username}}</div>
 			<div class="text">{{text}}</div>
 		</div>
-		<div class="timestamp">{{time}}</div>
+		<time class="timestamp" is="relative-time" datetime="{{timestamp}}"></time>
 	</section>
 </template>
 <script>
@@ -110,33 +111,7 @@ Polymer('x-chat-list', {
 	username: '',
 	text: '',
 	status: '',
-	timestamp: 1420145273945,
-
-	domReady: function() {
-		var d = new Date(this.timestamp);
-		var today =  new Date().getDate();
-
-		if (d.getDate() == today) { // show only time
-			var options = {hour: 'numeric', minute: 'numeric'};
-		} else { // show date
-			var options = {month: 'short', day: 'numeric'};
-		}
-
-		this.time = new Intl.DateTimeFormat(navigator.language, options).format(d);
-
-
-		// Realtime update
-		// if(diff < 60) { // less than 1 min
-		// 	this.time = (diff >>> 0) + 's';
-		// } else if (diff <  3600) { // less than 60 min
-		// 	this.time = ((diff/60) >>> 0) + 'm';
-		// } else if (diff < 86400) { // less than 24 hrs
-		// 	this.time = ((diff/3600) >>> 0) + 'h';
-		// } else {
-		// 	var d = new Date(this.timestamp);
-		// 	this.time = new Intl.DateTimeFormat(navigator.language, options).format(d);
-		// }
-	}
+	timestamp: new Date().toISOString(),
 });
 </script>
 </polymer-element>


### PR DESCRIPTION
Hey @girliemac,

First of all, good job in this tutorial. 

I noticed that there's [a bunch of code to display message's time](https://github.com/pubnub/paper-chat/blob/gh-pages/x-chat-list.html#L115-L139) inside the `x-chat-list` element. In this PR, I suggest using [GitHub's time-elements](https://github.com/github/time-elements).

File diff seems big but the real change required for this custom element to work is using `new Date().toISOString()` instead of `Date.now()`. See https://github.com/zenorocha/paper-chat/commit/b5523e8dd0b28577c6ffbf078d874e35ec942c98. The result would be something like this:

![screen shot 2015-02-16 at 6 42 04 pm](https://cloud.githubusercontent.com/assets/398893/6219668/997163c6-b60b-11e4-98f4-617029391ccd.png)

Let me know if you have any questions.
